### PR TITLE
Use GitHub document instead of wiki for the plugin page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <version>1.0.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Localization: Chinese (Simplified)</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/Localization-zh-cn+Plugin</url>
+  <url>https://github.com/jenkinsci/localization-zh-cn-plugin</url>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-406 -- pugins that have better docs in GitHub than Wiki should use GitHub.

### Submitter checklist

- [ ] [Know translation specification](https://github.com/jenkins-zh/translation-spec/blob/master/specification.md)

### Desired reviewers

@jenkinsci/chinese-localization-sig