### PR TITLE
Fixed a bug: java.io.FileNotFoundException: C:\Program%20Files%20(x86…

### DIFF
--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
@@ -32,8 +32,10 @@ public class UpdateCenterAction implements RootAction {
         }
 
         URL caRoot = context.getResource("/WEB-INF/update-center-rootCAs");
+        String crtPath = caRoot.getFile() + "/" + CRT;
+        String decodedCrtPath = crtPath.replaceAll("%20", " ");
         try (InputStream input = this.getClass().getResourceAsStream("/" + CRT);
-             OutputStream output = new FileOutputStream(new File(caRoot.getFile(), CRT))) {
+             OutputStream output = new FileOutputStream(new File(decodedCrtPath))) {
             if (input == null) {
                 LOGGER.warning("no mirror certificate found");
                 return;

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.logging.Logger;
 
 @Extension
@@ -32,8 +33,8 @@ public class UpdateCenterAction implements RootAction {
         }
 
         URL caRoot = context.getResource("/WEB-INF/update-center-rootCAs");
-        String crtPath = caRoot.getFile() + "/" + CRT;
-        String decodedCrtPath = crtPath.replaceAll("%20", " ");
+        String crtPath = caRoot.getFile() + CRT;
+        String decodedCrtPath = URLDecoder.decode(crtPath, "utf-8");
         try (InputStream input = this.getClass().getResourceAsStream("/" + CRT);
              OutputStream output = new FileOutputStream(new File(decodedCrtPath))) {
             if (input == null) {


### PR DESCRIPTION
Fixed a bug: java.io.FileNotFoundException: C:\Program%20Files%20(x86)\Jenkins\war\WEB-INF\update-center-rootCAs\mirror-adapter.crt

When Jenkins has been installed to a path which contains space on Windows, "C:\Program Files (x86)" for example, an exception will occur. 

### Submitter checklist

- [x] [Know translation specification](https://github.com/jenkins-zh/translation-spec/blob/master/specification.md)

### Desired reviewers

@jenkinsci/chinese-localization-sig
