### PR TITLE
Add the missing ManageCredentials translation and correct GlobalCredentials translation

### DIFF
--- a/plugins/credentials-plugin/src/main/resources/com/cloudbees/plugins/credentials/Messages_zh_CN.properties
+++ b/plugins/credentials-plugin/src/main/resources/com/cloudbees/plugins/credentials/Messages_zh_CN.properties
@@ -42,7 +42,7 @@ SystemCredentialsProvider.ProviderImpl.DisplayName=Jenkins \u51ED\u636E\u63D0\u4
 SystemCredentialsProvider.UserFacingAction.DisplayName=\u7CFB\u7EDF
 UserCredentialsProvider_DisplayName=\u51ED\u636E
 UserCredentialsProvider.UserFacingAction.DisplayName=\u7528\u6237
-GlobalCredentialsConfiguration.DisplayName=\u51ED\u636E\u914D\u7F6E
+GlobalCredentialsConfiguration.DisplayName=\u51ed\u636e\u63d0\u4f9b\u8005\u914d\u7f6e
 GlobalCredentialsConfiguration.Description=\u914D\u7F6E\u51ED\u636E\u7684\u63D0\u4F9B\u8005\u548C\u7C7B\u578B
 CredentialsProviderFilter.None.DisplayName=\u6240\u6709\u53EF\u89C1
 CredentialsProviderFilter.Includes.DisplayName=\u5305\u62EC\u9009\u62E9
@@ -52,3 +52,6 @@ CredentialsTypeFilter.Includes.DisplayName=\u5305\u62EC\u9009\u62E9
 CredentialsTypeFilter.Excludes.DisplayName=\u6392\u9664\u9009\u62E9
 CredentialsProviderTypeRestriction.Includes.DisplayName=\u5305\u62EC
 CredentialsProviderTypeRestriction.Excludes.DisplayName=\u6392\u9664
+
+ManageCredentialsConfiguration.displayName=\u51ed\u636e\u7ba1\u7406
+ManageCredentialsConfiguration.description=\u914d\u7f6e\u51ed\u636e


### PR DESCRIPTION
<!--
您好，非常高兴收到您的 PR。为了让我们可以更好地协作，请注意下面的事项：

* 请保留当前 PR 模板中的所有内容，包括注释，如果有需要添加的内容，直接添加即可
* 请您每次使用不同的分支来提交 PR，避免使用您的 master 来修改并提交
* 请您尽量给出一个可读性比较强的 PR 标题，这样方便维护者以及其他贡献者 review 以及检索

-->

### Submitter checklist

- [x] [Know translation specification](https://github.com/jenkins-zh/translation-spec/blob/master/specification.md)

Here is [an online tool](https://native2ascii.net/) which can help you to do the review work.

### Desired reviewers

@jenkinsci/chinese-localization-sig

[credentials-plugin](https://github.com/jenkinsci/credentials-plugin) 中遗留了部分中文翻译文件，我发起了 https://github.com/jenkinsci/credentials-plugin/pull/331 把这部分文件给移除，在本 PR 中补充了之前缺失的 `ManageCredentialsConfiguration`，修正了 `GlobalCredentialsConfiguration`的翻译。

#### Previous
<img width="773" alt="image" src="https://user-images.githubusercontent.com/19517509/175762066-d91a862c-b5d0-4cc9-bc16-83cba5bfad50.png">

#### After
<img width="721" alt="image" src="https://user-images.githubusercontent.com/19517509/175762058-b1f980ee-8ced-4e47-ac03-fff39a66b2b8.png">

