### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/CommunityPage.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/CommunityPage.java
@@ -1,11 +1,11 @@
 package io.jenkins.plugins.localization_zh_cn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import org.jenkinsci.Symbol;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 @Extension
 @Symbol("chinese")
@@ -16,7 +16,7 @@ public class CommunityPage implements UnprotectedRootAction {
         return null;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public String getDisplayName() {
         return "Jenkins Chinese Community";

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/LocalizationContributorImpl.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/LocalizationContributorImpl.java
@@ -1,18 +1,18 @@
 package io.jenkins.plugins.localization_zh_cn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.PluginWrapper;
 import io.jenkins.plugins.localization.support.LocalizationContributor;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.net.URL;
 
 @Extension
 public class LocalizationContributorImpl extends LocalizationContributor {
     @CheckForNull
     @Override
-    public URL getResource(@Nonnull String s) {
+    public URL getResource(@NonNull String s) {
         if (s.startsWith("/")) {
             s = s.substring(1);
         }
@@ -21,7 +21,7 @@ public class LocalizationContributorImpl extends LocalizationContributor {
 
     @CheckForNull
     @Override
-    public URL getPluginResource(@Nonnull String s, @Nonnull PluginWrapper pluginWrapper) {
+    public URL getPluginResource(@NonNull String s, @NonNull PluginWrapper pluginWrapper) {
         return getClass().getClassLoader().getResource("webapp/" + s);
     }
 }

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
@@ -9,7 +9,7 @@ import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/UserCommunityProperty.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/UserCommunityProperty.java
@@ -1,13 +1,12 @@
 package io.jenkins.plugins.localization_zh_cn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nonnull;
 
 public class UserCommunityProperty extends UserProperty {
     private String showCondition = ShowConditions.Chinese.name();
@@ -32,7 +31,7 @@ public class UserCommunityProperty extends UserProperty {
             return new UserCommunityProperty();
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Chinese Community";


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Confirmed that automated tests pass on Linux with Java 21.

### Submitter checklist

- [x] [Know translation specification](https://github.com/jenkins-zh/translation-spec/blob/master/specification.md)

Here is [an online tool](https://native2ascii.net/) which can help you to do the review work.

### Desired reviewers

@jenkinsci/chinese-localization-sig
