### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.7</version>
+    <relativePath />
   </parent>
 
   <artifactId>localization-zh-cn</artifactId>
@@ -14,15 +15,16 @@
   <url>https://github.com/jenkinsci/localization-zh-cn-plugin</url>
 
   <scm>
-    <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
   
   <properties>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.479.1</jenkins.version>
     <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
    </properties>
 
   <repositories>
@@ -181,10 +183,6 @@
   </build>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>symbol-annotation</artifactId>
-    </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>localization-support</artifactId>

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/CommunityDecorator.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/CommunityDecorator.java
@@ -4,14 +4,14 @@ import hudson.Extension;
 import hudson.model.PageDecorator;
 import hudson.model.User;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.Locale;
 
 @Extension
 public class CommunityDecorator extends PageDecorator {
     public boolean isCurrentLanguage() {
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if(req == null) {
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
+++ b/src/main/java/io/jenkins/plugins/localization_zh_cn/UpdateCenterAction.java
@@ -6,12 +6,12 @@ import hudson.model.RootAction;
 import java.nio.charset.StandardCharsets;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -23,13 +23,13 @@ public class UpdateCenterAction implements RootAction {
 
     @RequirePOST
     @SuppressFBWarnings(value = {"NP_LOAD_OF_KNOWN_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"}, justification = "Spotbugs doesn't grok try-with-resources")
-    public void doUse(StaplerResponse response) throws IOException {
+    public void doUse(StaplerResponse2 response) throws IOException {
         if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 
-        ServletContext context = Jenkins.get().servletContext;
+        ServletContext context = Jenkins.get().getServletContext();
         if (context == null) {
             LOGGER.warning("cannot get the servlet context when use the mirror certificate");
             return;
@@ -51,7 +51,7 @@ public class UpdateCenterAction implements RootAction {
     }
 
     @RequirePOST
-    public void doRemove(StaplerResponse response) throws IOException {
+    public void doRemove(StaplerResponse2 response) throws IOException {
         if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;


### PR DESCRIPTION
Migrate from deprecated EE 8 methods to non-deprecated EE 9 equivalents.